### PR TITLE
Fix for DjangoCMS 3.5: get_cms_setting

### DIFF
--- a/djangocms_reversion2/admin.py
+++ b/djangocms_reversion2/admin.py
@@ -8,7 +8,8 @@ from cms import api, constants
 from cms.admin.pageadmin import PageAdmin
 from cms.middleware.page import get_page
 from cms.models import Page, Title, EmptyTitle
-from cms.utils import get_cms_setting, get_language_from_request, get_language_list, i18n
+from cms.utils import get_language_from_request, get_language_list, i18n
+from cms.utils.conf import get_cms_setting
 from cms.utils import page_permissions
 from collections import defaultdict
 


### PR DESCRIPTION
ImportError: cannot import name get_cms_setting

Taken from https://github.com/nephila/djangocms-page-sitemap/commit/2c6ccdacc2c4e54cf0a12618d60c963d9c67ef62

The tests are still not fixed for some versions, but now the errors seem to make more sense.